### PR TITLE
chore(release): bump version to 4.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "motoko",
-    "version": "4.11.0",
+    "version": "4.12.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "motoko",
-            "version": "4.11.0",
+            "version": "4.12.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motoko",
-    "version": "4.11.0",
+    "version": "4.12.0",
     "description": "Compile and run Motoko smart contracts in Node.js or the browser.",
     "author": "Ryan Vandersmith (https://github.com/rvanasa)",
     "license": "Apache-2.0",


### PR DESCRIPTION
## Why

#187 landed the moc 1.15.0 bundle and the entry-point fix on `main`, but did not carry the npm version bump that the normal `update-moc` flow applies (`npm version minor`). Because `publish.yml` triggers only on a `package.json` change, the 1.15.0 bundle was never published to npm and vscode-motoko was never notified. This PR bumps the version so the release pipeline fires and consumers get moc 1.15.0.

## Scope

Bumps `version` to `4.12.0` in `package.json` and the root entry in `package-lock.json`. No dependency changes. This is the version the `update-moc` automation would have produced for the 1.15.0 update.

## Tradeoffs

Minor bump (4.11 -> 4.12) follows the update flow's default `npm version minor`. A patch bump would also trigger the pipeline but understate the compiler jump to 1.15.0.

## Blast Radius

On merge, `publish.yml` runs: type-check + test + `npm publish` to the `motoko` package, then a `repository_dispatch` to vscode-motoko to bump its dependency. Consumers on `motoko@4.11.0` (moc 1.11.0) move to moc 1.15.0.

## Verification

`npm run build` passes locally (type-check, matching the required build checks). The full `npm test` suite (40/40) passed on this tree earlier against the 1.15.0 bundle. The lockfile diff contains only the two root `version` fields.

Made with [Cursor](https://cursor.com)